### PR TITLE
chore: sync standard Lisp-Stat devcontainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+  "name": "statistics - Lisp-Stat Dev",
+  "image": "ghcr.io/lisp-stat/ls-dev:latest",
+  "containerUser": "vscode",
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "github.copilot",
+        "github.copilot-chat"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Sync: standard Lisp-Stat devcontainer config

This PR was opened automatically by the sync-devcontainer workflow
in the `lisp-stat/.github` repo.

### What changed
`.devcontainer/devcontainer.json` updated to match the canonical
template. The only repo-specific field is `name`.

### To update the template
Edit `.devcontainer/devcontainer-template.json` in `lisp-stat/.github`.
The sync workflow will open PRs in all other repos automatically.
