### PR TITLE
Improve loading the system in sbclb

### DIFF
--- a/src/batch.lisp
+++ b/src/batch.lisp
@@ -233,6 +233,6 @@ appearance when ties exist."
 
 
 ;;; Helpful shortcuts
-(defalias iqr interquartile-range)
+(setf (fdefinition 'iqr) #'interquartile-range)
 (export 'iqr)
 

--- a/src/pkgdcl.lisp
+++ b/src/pkgdcl.lisp
@@ -4,5 +4,8 @@
 
 (uiop:define-package #:statistics
   (:use #:cl #:let-plus)
+  (:import-from #:stat-generics
+                #:mean
+                #:variance)
   (:export #:mean
-	   #:variance))
+	         #:variance))

--- a/src/pkgdcl.lisp
+++ b/src/pkgdcl.lisp
@@ -1,9 +1,8 @@
 ;;; -*- Mode: LISP; Base: 10; Syntax: ANSI-Common-Lisp; Package: CL-USER -*-
 ;;; Copyright (c) 2022,2023,2026 by Symbolics Pte. Ltd. All rights reserved.
 ;;; SPDX-License-identifier: MS-PL
-(in-package :org.tfeb.clc-user)
 
-(uiop:define-package "statistics"
+(uiop:define-package #:statistics
   (:use #:cl #:let-plus)
   (:export #:mean
 	   #:variance))

--- a/statistics.asd
+++ b/statistics.asd
@@ -55,6 +55,8 @@
   :bug-tracker    "https://github.com/Lisp-Stat/statistics/issues"
   :depends-on ("statistics/streaming"
                "statistics/batch")
+  :pathname "src/"
+  :components ((:file "pkgdcl"))
   :in-order-to ((test-op (test-op "statistics/tests"))))
 
 (defsystem "statistics/tests"


### PR DESCRIPTION
Thank you for getting together this project.
When trying to use it I encounter few minor issues so far that I try to address in this PR.

1. UNBOUND-VARIABLE IQR
```
 (ql:quickload :lisp-stat)
; Loading "lisp-stat"
............
; Debugger entered on #<UNBOUND-VARIABLE IQR {12055BD0A3}>
```
This is due to missing definition of `defalias` macro(function) in sbcl.

2. No package named :STATISTICS

```
(ql:quickload :statistics)
debugger invoked on a ORG.TFEB.CONDUIT-PACKAGES::CONDUIT-ERROR in thread
  No package named :STATISTICS
```

3. missing definitions of exported `variance` and `mean` fn in `statistics` package

I guess this is left from some larger changes and their export could be removed.
To avoid breaking changes I decided for time being import them from `:stat-generics`